### PR TITLE
Add Syslog driver

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -8,11 +8,12 @@ gem 'i18n'
 gem 'delorean'
 
 # Drivers
-gem 'amqp',     :require => false
-gem 'bunny',    :require => false
-gem 'redis',    :require => false
-gem 'em-redis', :require => false
-gem 'ffi',      :require => false
-gem 'ffi-rzmq', :require => false
+gem 'amqp',            :require => false
+gem 'bunny',           :require => false
+gem 'redis',           :require => false
+gem 'em-redis',        :require => false
+gem 'ffi',             :require => false
+gem 'ffi-rzmq',        :require => false
+gem 'syslog_protocol', :require => false
 
 gemspec

--- a/lib/eventwire/drivers.rb
+++ b/lib/eventwire/drivers.rb
@@ -4,5 +4,6 @@ module Eventwire
     autoload :AMQP,      'eventwire/drivers/amqp'
     autoload :Redis,     'eventwire/drivers/redis'
     autoload :Zero,      'eventwire/drivers/zero'
+    autoload :Syslog,    'eventwire/drivers/syslog'
   end
 end

--- a/lib/eventwire/drivers/in_process.rb
+++ b/lib/eventwire/drivers/in_process.rb
@@ -2,21 +2,21 @@ class Eventwire::Drivers::InProcess
   def initialize
     @handlers = {}
   end
-  
+
   def handlers(event_name)
     @handlers[event_name] ||= []
   end
-  
+
   def publish(event_name, event_data = nil)
     handlers(event_name).each do |handler|
       handler.call event_data
     end
   end
-  
+
   def subscribe(event_name, handler_id, &handler)
     handlers(event_name) << handler
   end
-  
+
   def start; end
   def stop; end
   def purge; end

--- a/lib/eventwire/drivers/syslog.rb
+++ b/lib/eventwire/drivers/syslog.rb
@@ -1,0 +1,174 @@
+require 'eventmachine'
+require 'syslog_protocol'
+
+# SYSLOG DRIVER
+#
+# Syslog driver allows using the standard syslog as a queue.
+#
+# By default writes to the local machine to the port 514 where usually listen
+# programs like rsyslog or syslog-ng. That program could send the logs to other
+# machines.
+#
+# By default Syslog uses facility *local0* so you can use that facility to say
+# to the syslog daemon where to send that messages
+#
+# The severity by default is *notice*.
+#
+# In the other machine, you can run the worker that by default will listen in
+# port 514 (syslog port). If you want your worker to not run as a privileged
+# daemon, you should use other port (> 1024) and say to the syslog daemon to
+# forward messages to your port.
+#
+# By default syslog listen and writes in 127.0.0.1
+#
+# ADVANTAGES
+#
+#   * Probably the fastest ways to send messages
+#
+# DISADVANTAGES
+#
+#   * No confirmation
+#   * Only one program can listen in one port at the same time (as far as I know)
+#   * Have a few limitations
+#
+# LIMITATIONS
+#
+#   * The syslog protocol only allows packets of 1024 bytes so the message
+#     should be short enough. In that packet will go a timestamp, facillity,
+#     severity, hostname, and message.
+#   * Only the key *content* of the hash passed to _publish_ will be transmited.
+#     The rest of the keys will be silently ignored.
+#
+# @example Creation
+#   options = {}
+#   Syslog.new(options)
+#
+# And the options that chould be changes are:
+#
+#   DEFAULT_OPTIONS = {
+#     :subscriber_listen_port         => '514',
+#     :subscriber_listen_interface    => '127.0.0.1',
+#     :publisher_destination_host => '127.0.0.1',
+#     :publisher_destination_port => '514',
+#     :facility                   => 'local0',
+#     :severity                   => 'notice',
+#     :hostname                   => `hostname`.strip
+#   }
+#
+# EXTRAS
+#
+# The syslog protocol send messages with a little more information. You can access
+# that information when receiving a packet:
+#
+# @example Extras
+#   class Notifier
+#     include Eventwire::Subscriber
+#
+#     on :task_completed do |event|
+#       event.facility #=> 16
+#       event.severity #=> 5
+#       event.hostname #=> the hostname of the maching that send the event
+#       event.tag      #=> "task_completed"
+#       event.time     #=> an instance of Time with the time the event was generated
+#       event.content  #=> the content send with publish
+#     end
+#   end
+#
+# RSYSLOG CHEATSHEET
+#
+# If you want a server to listen in certain port, you should add to rsyslog.conf
+#
+#   $ModLoad imudp    # Load udp module
+#   $UDPServerRun 514 # And listen on port 514
+#
+# If you want to fordware messages to other machine:
+#
+#   *.* @www.google.com
+#
+# If you want to forward messages from another port of the current machine
+#
+#   *.* @localhost:5514
+#
+class Eventwire::Drivers::Syslog #:nodoc: all
+  include SyslogProtocol
+
+  @@handlers = {}
+
+
+  DEFAULT_OPTIONS = {
+    :subscriber_listen_port      => '514',
+    :subscriber_listen_interface => '127.0.0.1',
+    :publisher_destination_host  => '127.0.0.1',
+    :publisher_destination_port  => '514',
+    :facility                    => 'local0',
+    :severity                    => 'notice',
+    :hostname                    => `hostname`.strip
+  }
+
+  class SysLogConnection < ::EventMachine::Connection
+    def receive_data(data)
+      packet = SyslogProtocol.parse(data)
+      ::Eventwire::Drivers::Syslog.handlers(packet.tag).each do |handler|
+        message = {
+          :content  => packet.content,
+          :facility => packet.facility,
+          :severity => packet.severity,
+          :hostname => packet.hostname,
+          :tag      => packet.tag,
+          :time     => packet.time
+        }
+        handler.call(message)
+      end
+    end
+  end
+
+  def initialize(options = {})
+    @options = DEFAULT_OPTIONS.merge(options)
+  end
+
+  def self.handlers(event_name)
+    @@handlers[event_name.to_s] ||= []
+  end
+
+  def handlers(event_name)
+    self.class.handlers(event_name)
+  end
+
+  def publish(event_name, event_data = nil)
+    packet          = Packet.new
+    packet.tag      = event_name.to_s
+    packet.severity = @options[:severity]
+    packet.facility = @options[:facility]
+    packet.hostname = @options[:hostname]
+    packet.content  = event_data && event_data[:content]
+
+    host = @options[:publisher_destination_host]
+    port = @options [:publisher_destination_port]
+
+    UDPSocket.new.send packet.to_s, 0, host, port
+  end
+
+  def subscribe(event_name, handler_id, &handler)
+    handlers(event_name) << handler
+  end
+
+  def start
+    EventMachine.run do
+      interface = @options[:subscriber_listen_interface]
+      port = @options[:subscriber_listen_port]
+
+      EventMachine::open_datagram_socket(interface, port , SysLogConnection)
+    end
+  end
+
+  def stop
+    ::EventMachine.stop if EventMachine.reactor_running?
+  end
+
+  def purge
+  end
+end
+
+
+
+

--- a/spec/spec_helper.rb
+++ b/spec/spec_helper.rb
@@ -7,7 +7,7 @@ module Helpers
   def class_including(mod)
     Class.new.tap {|c| c.send :include, mod }
   end
-  
+
   def eventually(timeout = 1, &block)
     # Expectations must be met in less that timeout secs
     start = Time.now
@@ -20,17 +20,17 @@ module Helpers
         sleep 0.001
       end
     end
-    
+
     # Expectations must keep being met for at least 0.5 secs
     5.times { block.call; sleep 0.1 }
   end
-  
+
 end
 
 RSpec.configure do |config|
   config.include Delorean
   config.include Helpers
-  
+
   config.after do
     Eventwire.driver = nil
   end

--- a/spec/unit/drivers/drivers_helper.rb
+++ b/spec/unit/drivers/drivers_helper.rb
@@ -1,6 +1,7 @@
 require 'spec_helper'
 require 'timeout'
 
+
 shared_examples_for 'a driver' do
   
   def start_worker
@@ -21,35 +22,35 @@ shared_examples_for 'a driver' do
   it 'should publish to 1 event handler' do
     executed = false
     subject.subscribe(:this_event, :this_subscriber) { executed = true }
-    
+
     start_worker
     subject.publish :this_event
-    
+
     eventually {
       executed.should be_true
     }
   end
-  
+
   it 'should publish to more than 1 event handler for the event' do
     executed = [false, false]
     subject.subscribe(:this_event, :queue2) { executed[0] = true }
     subject.subscribe(:this_event, :queue1) { executed[1] = true }
-    
+
     start_worker
     subject.publish :this_event
-    
+
     eventually {
       executed.should == [true, true]
     }
   end
-  
+
   it 'should not publish to handlers for other events' do
     executed = false
     subject.subscribe(:other_event, :this_subscriber) { executed = true }
-    
+
     start_worker
     subject.publish :this_event
-    
+
     eventually {
       executed.should be_false
     }
@@ -66,7 +67,7 @@ shared_examples_for 'a driver' do
       event_data.should == { 'key1' => 'value1', 'key2' => 2 }
     }
   end
-  
+
 end
 
 shared_examples_for 'a driver with multiprocess support' do
@@ -77,7 +78,7 @@ shared_examples_for 'a driver with multiprocess support' do
     @shoutings = 0
     @ppid = Process.pid
   end
-  
+
   def process(&block)
     pid = fork do
       trap('INT') { subject.stop; subject.purge }
@@ -86,50 +87,50 @@ shared_examples_for 'a driver with multiprocess support' do
     @children << pid
     pid
   end
-  
+
   after do
     @children.each {|p| kill_and_wait(p) rescue nil }
   end
-  
+
   def kill_and_wait(pid)
     Process.kill('INT', pid)
     Process.wait(pid)
   end
-  
+
   def shout!
     Process.kill 'USR1', @ppid
   end
-  
+
   example 'one subscriber' do
-    process do   
+    process do
       subject.subscribe(:this_event, :this_subscriber) { shout! }
       subject.start
     end
-    
+
     process do
       subject.publish :this_event
     end
-    
+
     eventually do
       @shoutings.should == 1
     end
   end
-  
+
   example 'several subscribers' do
     process do
       subject.subscribe(:this_event, :first_subscriber) { shout! }
       subject.start
     end
-    
+
     process do
       subject.subscribe(:this_event, :other_subscriber) { shout! }
       subject.start
     end
-    
+
     process do
       subject.publish :this_event
     end
-    
+
     eventually do
       @shoutings.should == 2
     end

--- a/spec/unit/drivers/drivers_helper.rb
+++ b/spec/unit/drivers/drivers_helper.rb
@@ -41,17 +41,21 @@ shared_examples_for 'a driver' do
       executed.should be_false
     }
   end
-  
-  it 'should pass the event data to the event handlers' do
-    event_data = nil
-    subject.subscribe(:this_event, :this_subscriber) { |data| event_data = data }
-    
-    start_worker
-    subject.publish :this_event, 'key1' => 'value1', 'key2' => 2
-    
-    eventually {
-      event_data.should == { 'key1' => 'value1', 'key2' => 2 }
-    }
+
+  unless superclass_metadata[:no_content_spec]
+
+    it 'should pass the event data to the event handlers' do
+      event_data = nil
+      subject.subscribe(:this_event, :this_subscriber) { |data| event_data = data }
+
+      start_worker
+      subject.publish :this_event, 'key1' => 'value1', 'key2' => 2
+
+      eventually {
+        event_data.should == { 'key1' => 'value1', 'key2' => 2 }
+      }
+    end
+
   end
 
 end

--- a/spec/unit/drivers/syslog_spec.rb
+++ b/spec/unit/drivers/syslog_spec.rb
@@ -1,0 +1,47 @@
+require 'unit/drivers/drivers_helper'
+
+# Don't need root privilegies to run in test mode
+Eventwire::Drivers::Syslog::DEFAULT_OPTIONS[:publisher_destination_port] = 5514
+Eventwire::Drivers::Syslog::DEFAULT_OPTIONS[:subscriber_listen_port] = 5514
+
+describe Eventwire::Drivers::Syslog, :no_content_spec => true do
+  include WorkerHelper
+
+  it_should_behave_like 'a driver'
+
+  it "should transfer the content" do
+    event_data = nil
+    subject.subscribe(:this_event, :this_subscriber) { |data| event_data = data }
+
+    start_worker
+
+    subject.publish :this_event, :content => "wadus"
+
+    eventually {
+      sleep_until_no_nil { event_data }
+      event_data[:content].should == "wadus"
+    }
+  end
+
+
+  it "should contain metada" do
+    event_data = nil
+    subject.subscribe(:this_event, :this_subscriber) { |data| event_data = data }
+
+    start_worker
+
+    subject.publish :this_event, :content => "wadus"
+
+    eventually {
+      sleep_until_no_nil { event_data }
+      event_data[:facility].should == 16
+      event_data[:severity].should == 5
+      event_data[:hostname].should == `hostname`.strip
+      event_data[:tag].should == 'this_event'
+      event_data[:time].should be_instance_of(Time)
+    }
+  end
+
+
+
+end


### PR DESCRIPTION
The normal use case for this patch, is for common login things. For example, put application errors or user actions into the syslogs makes it possible to track application errors in realtime while also saving it to files.

One problem with the tests was found in the spec that tries to check content integrity. That test should be disabled as (explained in the documentation) the syslog format should be less that 1024 bytes.

Only the value in the "content" key on the hash passed to publish will be transmited.

In the subscription part, the rest of the information of the syslog will be available as more keys in the message received.
