### PR TITLE
Multi json

### DIFF
--- a/eventwire.gemspec
+++ b/eventwire.gemspec
@@ -17,6 +17,6 @@ Gem::Specification.new do |s|
   s.test_files    = `git ls-files -- {test,spec,features}/*`.split("\n")
   s.executables   = `git ls-files -- bin/*`.split("\n").map{ |f| File.basename(f) }
   s.require_paths = ['lib']
-  
-  s.add_dependency 'json'
+
+  s.add_dependency 'multi_json'
 end

--- a/lib/eventwire/drivers.rb
+++ b/lib/eventwire/drivers.rb
@@ -1,4 +1,4 @@
-require 'json'
+require 'multi_json'
 
 module Eventwire
   module Drivers

--- a/lib/eventwire/drivers.rb
+++ b/lib/eventwire/drivers.rb
@@ -1,5 +1,3 @@
-require 'multi_json'
-
 module Eventwire
   module Drivers
     autoload :InProcess, 'eventwire/drivers/in_process'

--- a/lib/eventwire/drivers/amqp.rb
+++ b/lib/eventwire/drivers/amqp.rb
@@ -4,7 +4,7 @@ require 'amqp'
 class Eventwire::Drivers::AMQP
   def publish(event_name, event_data = nil)
     Bunny.run do |mq|
-      mq.exchange(event_name.to_s, :type => :fanout).publish(MultiJson.encode(event_data))
+      mq.exchange(event_name.to_s, :type => :fanout).publish(ActiveSupport::JSON.encode(event_data))
     end    
   end
 
@@ -34,7 +34,7 @@ class Eventwire::Drivers::AMQP
   end
   
   def parse_json(json)
-    json != 'null' && MultiJson.decode(json)
+    json != 'null' && ActiveSupport::JSON.decode(json)
   end
 
   def subscriptions

--- a/lib/eventwire/drivers/amqp.rb
+++ b/lib/eventwire/drivers/amqp.rb
@@ -4,7 +4,7 @@ require 'amqp'
 class Eventwire::Drivers::AMQP
   def publish(event_name, event_data = nil)
     Bunny.run do |mq|
-      mq.exchange(event_name.to_s, :type => :fanout).publish(event_data.to_json)
+      mq.exchange(event_name.to_s, :type => :fanout).publish(MultiJson.encode(event_data))
     end    
   end
 
@@ -34,7 +34,7 @@ class Eventwire::Drivers::AMQP
   end
   
   def parse_json(json)
-    json != 'null' && JSON.parse(json) 
+    json != 'null' && MultiJson.decode(json)
   end
 
   def subscriptions

--- a/lib/eventwire/drivers/bunny.rb
+++ b/lib/eventwire/drivers/bunny.rb
@@ -4,7 +4,7 @@ class Eventwire::Drivers::Bunny
   
   def publish(event_name, event_data = nil)
     Bunny.run do |mq|
-      mq.exchange(event_name.to_s, :type => :fanout).publish(event_data.to_json)
+      mq.exchange(event_name.to_s, :type => :fanout).publish(MultiJson.encode(event_data))
     end
   end
 
@@ -46,7 +46,7 @@ class Eventwire::Drivers::Bunny
   end
   
   def parse_json(json)
-    json != 'null' && JSON.parse(json) 
+    json != 'null' && MultiJson.decode(json)
   end
 
   def subscriptions

--- a/lib/eventwire/drivers/bunny.rb
+++ b/lib/eventwire/drivers/bunny.rb
@@ -4,7 +4,7 @@ class Eventwire::Drivers::Bunny
   
   def publish(event_name, event_data = nil)
     Bunny.run do |mq|
-      mq.exchange(event_name.to_s, :type => :fanout).publish(MultiJson.encode(event_data))
+      mq.exchange(event_name.to_s, :type => :fanout).publish(ActiveSupport::JSON.encode(event_data))
     end
   end
 
@@ -46,7 +46,7 @@ class Eventwire::Drivers::Bunny
   end
   
   def parse_json(json)
-    json != 'null' && MultiJson.decode(json)
+    json != 'null' && ActiveSupport::JSON.decode(json)
   end
 
   def subscriptions

--- a/lib/eventwire/drivers/redis.rb
+++ b/lib/eventwire/drivers/redis.rb
@@ -10,7 +10,7 @@ class Eventwire::Drivers::Redis
     redis = ::Redis.new
     handlers = redis.smembers("event_handlers:#{event_name}")
     handlers.each do |handler|
-      redis.rpush handler, MultiJson.encode(event_data)
+      redis.rpush handler, ActiveSupport::JSON.encode(event_data)
     end
   end
 
@@ -42,7 +42,7 @@ class Eventwire::Drivers::Redis
   end
   
   def parse_json(json)
-    json != 'null' && MultiJson.decode(json)
+    json != 'null' && ActiveSupport::JSON.decode(json)
   end
   
   def purge

--- a/lib/eventwire/drivers/redis.rb
+++ b/lib/eventwire/drivers/redis.rb
@@ -10,7 +10,7 @@ class Eventwire::Drivers::Redis
     redis = ::Redis.new
     handlers = redis.smembers("event_handlers:#{event_name}")
     handlers.each do |handler|
-      redis.rpush handler, event_data.to_json
+      redis.rpush handler, MultiJson.encode(event_data)
     end
   end
 
@@ -42,7 +42,7 @@ class Eventwire::Drivers::Redis
   end
   
   def parse_json(json)
-    json != 'null' && JSON.parse(json) 
+    json != 'null' && MultiJson.decode(json)
   end
   
   def purge

--- a/lib/eventwire/drivers/zero.rb
+++ b/lib/eventwire/drivers/zero.rb
@@ -5,7 +5,7 @@ class Eventwire::Drivers::Zero
     ctx = ZMQ::Context.new
     s = ctx.socket ZMQ::PUSH
     s.connect("tcp://127.0.0.1:5560")
-    s.send_string(MultiJson.encode([event_name, event_data]))
+    s.send_string(ActiveSupport::JSON.encode([event_name, event_data]))
     s.close
     ctx.terminate
   end
@@ -42,7 +42,7 @@ class Eventwire::Drivers::Zero
   end
   
   def parse_json(json)
-    json != 'null' && MultiJson.decode(json)
+    json != 'null' && ActiveSupport::JSON.decode(json)
   end
   
   def purge; end

--- a/lib/eventwire/drivers/zero.rb
+++ b/lib/eventwire/drivers/zero.rb
@@ -5,7 +5,7 @@ class Eventwire::Drivers::Zero
     ctx = ZMQ::Context.new
     s = ctx.socket ZMQ::PUSH
     s.connect("tcp://127.0.0.1:5560")
-    s.send_string([event_name, event_data].to_json)
+    s.send_string(MultiJson.encode([event_name, event_data]))
     s.close
     ctx.terminate
   end
@@ -42,7 +42,7 @@ class Eventwire::Drivers::Zero
   end
   
   def parse_json(json)
-    json != 'null' && JSON.parse(json) 
+    json != 'null' && MultiJson.decode(json)
   end
   
   def purge; end


### PR DESCRIPTION
The bundled JSON encoder in MultiJson has issues encoding objects that don't have #to_json (like Time in 1.8.7). The rails guys wrapped MultiJson with ActiveSupport::JSON to fix those issues. I've updated the references to use ActiveSupport::JSON and ran the specs on 1.8.7 and 1.9.2.
