### PR TITLE
Exclude ruby-debug installation on travis-ci.org 

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -7,8 +7,10 @@ gem 'delorean'
 gem 'rake'
 gem 'bson_ext'
 
-gem 'ruby-debug',   :platforms => :mri_18
-gem 'ruby-debug19', :platforms => :mri_19
+unless ENV["CI"]
+  gem 'ruby-debug',   :platforms => :mri_18
+  gem 'ruby-debug19', :platforms => :mri_19
+end
 
 # Drivers
 gem 'amqp',     :require => false


### PR DESCRIPTION
For reasoning please see «Exclude non-essential gems like ruby-debug» section [in our documentation](http://about.travis-ci.org/docs/user/languages/ruby/).
