### PR TITLE
Specs can be run only for specific adapters

### DIFF
--- a/Rakefile
+++ b/Rakefile
@@ -1,6 +1,17 @@
 require 'bundler/gem_tasks'
 require 'rspec/core/rake_task'
 
-RSpec::Core::RakeTask.new(:spec)
-
 task :default => :spec
+
+desc 'Run specs for all drivers (or specify them using ADAPTERS environment variable)'
+RSpec::Core::RakeTask.new(:spec) do |t|
+  adapter_specs = if ENV['ADAPTERS']
+    ENV['ADAPTERS'].split(',').map do |adapter|
+      "spec/integration/drivers/#{adapter}_spec.rb"
+    end
+  else
+    ['spec/integration/**/*_spec.rb']
+  end
+  t.pattern = ['spec/{unit,acceptance}/**/*_spec.rb'] + adapter_specs
+end
+

--- a/spec/acceptance/project_management_spec.rb
+++ b/spec/acceptance/project_management_spec.rb
@@ -1,8 +1,22 @@
 require 'spec_helper'
 
 describe 'Project Management System' do
+
+  mappings = {
+    'in_process' => 'InProcess',
+    'amqp'       => 'AMQP',
+    'redis'      => 'Redis'
+  }
   
-  drivers = %w{InProcess AMQP Redis}
+  drivers = if ENV['ADAPTERS']
+    [].tap do |drivers|
+      ENV['ADAPTERS'].split(',').each do |driver|
+        drivers << mappings[driver]
+      end
+    end.compact
+  else
+    mappings.values
+  end
 
   drivers.each do |driver|
 


### PR DESCRIPTION
Now you can run the specs only for some specific drivers (just in case you're not interested in running in some of them and feel lazy about installing Redis, Mongo, etc.).

```
$ rake ADAPTERS=in_process,amqp
```

The default behavior, when you don't use `ADAPTERS`, is to run for all adapters (just like before).
