### PR TITLE
Add EXCEPT and ONLY options to specs in order to select the drivers you want to test

### DIFF
--- a/Rakefile
+++ b/Rakefile
@@ -1,17 +1,6 @@
 require 'bundler/gem_tasks'
 require 'rspec/core/rake_task'
 
+RSpec::Core::RakeTask.new(:spec)
+
 task :default => :spec
-
-desc 'Run specs for all drivers (or specify them using ADAPTERS environment variable)'
-RSpec::Core::RakeTask.new(:spec) do |t|
-  adapter_specs = if ENV['ADAPTERS']
-    ENV['ADAPTERS'].split(',').map do |adapter|
-      "spec/integration/drivers/#{adapter}_spec.rb"
-    end
-  else
-    ['spec/integration/**/*_spec.rb']
-  end
-  t.pattern = ['spec/{unit,acceptance}/**/*_spec.rb'] + adapter_specs
-end
-

--- a/spec/acceptance/project_management_spec.rb
+++ b/spec/acceptance/project_management_spec.rb
@@ -1,22 +1,8 @@
 require 'spec_helper'
 
 describe 'Project Management System' do
-
-  mappings = {
-    'in_process' => 'InProcess',
-    'amqp'       => 'AMQP',
-    'redis'      => 'Redis'
-  }
   
-  drivers = if ENV['ADAPTERS']
-    [].tap do |drivers|
-      ENV['ADAPTERS'].split(',').each do |driver|
-        drivers << mappings[driver]
-      end
-    end.compact
-  else
-    mappings.values
-  end
+  drivers = %w{InProcess AMQP Redis}
 
   drivers.each do |driver|
 

--- a/spec/acceptance/project_management_spec.rb
+++ b/spec/acceptance/project_management_spec.rb
@@ -1,12 +1,12 @@
 require 'spec_helper'
 
 describe 'Project Management System' do
-  
+
   drivers = %w{InProcess AMQP Redis}
 
   drivers.each do |driver|
 
-    context "using the #{driver} driver" do
+    with_driver driver do
 
       before do
         Eventwire.driver = driver
@@ -51,7 +51,7 @@ describe 'Project Management System' do
     end
 
   end
-  
+
   private
 
   def start_worker

--- a/spec/integration/drivers/amqp_spec.rb
+++ b/spec/integration/drivers/amqp_spec.rb
@@ -1,6 +1,6 @@
 require 'integration/drivers/drivers_helper'
 
-describe Eventwire::Drivers::AMQP do
+describe_driver Eventwire::Drivers::AMQP do
   it_should_behave_like 'a driver with single-process support'
   it_should_behave_like 'a driver with multi-process support'
 end

--- a/spec/integration/drivers/bunny_spec.rb
+++ b/spec/integration/drivers/bunny_spec.rb
@@ -1,6 +1,6 @@
 require 'integration/drivers/drivers_helper'
 
-describe Eventwire::Drivers::Bunny do
+describe_driver Eventwire::Drivers::Bunny do
   it_should_behave_like 'a driver with single-process support'
   it_should_behave_like 'a driver with multi-process support'
 end

--- a/spec/integration/drivers/in_process_spec.rb
+++ b/spec/integration/drivers/in_process_spec.rb
@@ -1,5 +1,5 @@
 require 'integration/drivers/drivers_helper'
 
-describe Eventwire::Drivers::InProcess do
+describe_driver Eventwire::Drivers::InProcess do
   it_should_behave_like 'a driver with single-process support'
 end

--- a/spec/integration/drivers/mongo_spec.rb
+++ b/spec/integration/drivers/mongo_spec.rb
@@ -1,6 +1,6 @@
 require 'integration/drivers/drivers_helper'
 
-describe Eventwire::Drivers::Mongo do
+describe_driver Eventwire::Drivers::Mongo do
   it_should_behave_like 'a driver with single-process support'
   it_should_behave_like 'a driver with multi-process support'
 end

--- a/spec/integration/drivers/redis_spec.rb
+++ b/spec/integration/drivers/redis_spec.rb
@@ -1,6 +1,6 @@
 require 'integration/drivers/drivers_helper'
 
-describe Eventwire::Drivers::Redis do
+describe_driver Eventwire::Drivers::Redis do
   it_should_behave_like 'a driver with single-process support'
   it_should_behave_like 'a driver with multi-process support'
 end

--- a/spec/spec_helper.rb
+++ b/spec/spec_helper.rb
@@ -1,31 +1,9 @@
 require 'rubygems'
 require 'bundler'
-require File.join(File.dirname(__FILE__), 'support', 'drivers')
+
+Dir[File.expand_path(File.join(File.dirname(__FILE__), 'support', '**', '*.rb'))].each { |f| require f }
 
 Bundler.require
-
-module Helpers
-  def class_including(mod)
-    Class.new.tap {|c| c.send :include, mod }
-  end
-  
-  def eventually(timeout = 1, &block)
-    # Expectations must be met in less that timeout secs
-    start = Time.now
-    loop do
-      begin
-        block.call
-        break
-      rescue RSpec::Expectations::ExpectationNotMetError
-        raise if Time.now - start > timeout
-        sleep 0.001
-      end
-    end
-    
-    # Expectations must keep being met for at least 0.5 secs
-    5.times { block.call; sleep 0.1 }
-  end
-end
 
 include Drivers
 

--- a/spec/spec_helper.rb
+++ b/spec/spec_helper.rb
@@ -1,5 +1,6 @@
 require 'rubygems'
 require 'bundler'
+require File.join(File.dirname(__FILE__), 'support', 'drivers')
 
 Bundler.require
 
@@ -24,8 +25,9 @@ module Helpers
     # Expectations must keep being met for at least 0.5 secs
     5.times { block.call; sleep 0.1 }
   end
-  
 end
+
+include Drivers
 
 def sleep(time)
   factor = ENV['SLEEP_FACTOR'] || 1

--- a/spec/support/drivers.rb
+++ b/spec/support/drivers.rb
@@ -1,0 +1,34 @@
+module Drivers
+  def describe_driver(driver_class, &block)
+    driver = driver_class.to_s.gsub(/^.*::/, '')
+    describe(driver_class, &block) if should_be_tested?(driver)
+  end
+
+  def with_driver(driver, &block)
+    if should_be_tested?(driver)
+      context "using the #{driver} driver", &block
+    end
+  end
+
+  def should_be_tested?(driver)
+    return true if selected.nil? && excluded.nil?
+    return selected?(driver) if selected
+    return !excluded?(driver) if excluded
+  end
+
+  def selected
+    ENV['ONLY'].split(',') if ENV['ONLY']
+  end
+
+  def excluded
+    ENV['EXCEPT'].split(',') if ENV['EXCEPT']
+  end
+
+  def selected?(driver)
+    selected.include?(driver)
+  end
+
+  def excluded?(driver)
+    excluded.include?(driver)
+  end
+end

--- a/spec/support/helpers.rb
+++ b/spec/support/helpers.rb
@@ -1,0 +1,22 @@
+module Helpers
+  def class_including(mod)
+    Class.new.tap {|c| c.send :include, mod }
+  end
+  
+  def eventually(timeout = 1, &block)
+    # Expectations must be met in less that timeout secs
+    start = Time.now
+    loop do
+      begin
+        block.call
+        break
+      rescue RSpec::Expectations::ExpectationNotMetError
+        raise if Time.now - start > timeout
+        sleep 0.001
+      end
+    end
+    
+    # Expectations must keep being met for at least 0.5 secs
+    5.times { block.call; sleep 0.1 }
+  end
+end


### PR DESCRIPTION
This is just a better implementation of our last pull request (#27). Apart for being cleaner, it also supports excluding drivers and not only including them. It works both with and without using `rake`.

Examples:

```
$ ONLY=InProcess,Bunny rake

$ EXCEPT=AMQP,Redis rspec spec/acceptance

```

Just a question: where do you think would be the best place to document this?

Thanks!
